### PR TITLE
新規ユーザー登録、予約履歴関連のレイアウトの調整

### DIFF
--- a/src/main/resources/static/css/history-contents.css
+++ b/src/main/resources/static/css/history-contents.css
@@ -1,0 +1,131 @@
+@charset "UTF-8";
+
+
+/**
+ * 予約履歴
+ */
+
+.history-list {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	margin: 32px 0;
+}
+
+.list-contents {
+	display: flex;
+	width: 80%;
+	box-shadow: 1px 1px 2px 1px rgba(5, 5, 5, 0.1);
+	border-radius: 8px;
+	appearance: none;
+}
+
+.history-info {
+	width: 100%;
+	padding: 0px 24px;
+}
+
+.history-img {
+	max-width: 320px;
+	height: 100%;
+	border-radius: 8px 0px 0px 8px;
+}
+
+.theme-color {
+	color: #e77611;
+}
+
+.history-info__btn {
+	display: flex;
+	justify-content: end;
+	gap: 8px;
+	margin: 16px 0;
+}
+
+.review-btn {
+	width: 168px;
+	padding: 8px;
+	background-color: #fff;
+	color: rgb(236, 146, 78);
+	border: 1px solid rgba(236, 146, 78, 0.3);
+	border-radius: 5px;
+}
+
+.review-btn:hover {
+	background-color: rgba(236, 146, 78, 0.1);
+	border: 1px solid rgba(236, 146, 78, 0.3);
+}
+
+.history-btn {
+	width: 168px;
+	padding: 8px;
+	background-color: #fff;
+	color: rgb(74, 144, 226);
+	border: 1px solid rgba(74, 144, 226, 0.3);
+	border-radius: 5px;
+}
+
+.history-btn:hover {
+	background-color: rgba(74, 144, 226, 0.1);
+	border: 1px solid rgba(74, 144, 226, 0.3);
+}
+
+.review-disabled {
+	width: 168px;
+	padding: 8px;
+	background-color: #f8f9fa;
+	color: #adb5bd;
+	border: 1px solid #dee2e6;
+	border-radius: 5px;
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.review-disabled:hover {
+	background-color: #f8f9fa;
+	border: 1px solid #dee2e6;
+	cursor: not-allowed;
+}
+
+/**
+ * 予約履歴詳細
+ */
+
+.history-detail__img {
+	display: block;
+	max-width: 600px;
+	margin: 0 auto 24px auto;
+}
+
+.history-detail__contents {
+	width: 60%;
+	box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.1);
+	border-radius: 8px;
+	margin: 0 auto;
+	padding: 2rem 3rem;
+}
+
+.detail-contents-row {
+	display: flex;
+	padding: 1.2rem;
+	border-bottom: 1px solid rgba(5, 5, 5, 0.1);
+}
+.detail-contents-row:last-child {
+	border: none;
+}
+
+.detail-contents__title {
+	width: 40%;
+	font-weight: 600;
+}
+
+.detail-contents__body {
+	flex: 1;
+}
+
+.history-detail-btn button{
+	display: block;
+	width: 168px;
+	margin: 24px auto;
+	padding: 1rem 2rem;
+}

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -4,54 +4,82 @@
 <head>
 	<meta charset="UTF-8">
 	<title>ユーザー新規登録</title>
+	<!-- フォントやアイコンなどの読み込み -->
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
+	<!-- Font Awesome -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+	<!-- 共通CSS -->
+	<link rel="stylesheet" href="/css/style.css">
+	<link rel="stylesheet" href="/css/shadow.css">
+	<link rel="stylesheet" href="/css/button.css">
+	<link rel="stylesheet" href="/css/header-footer.css">
+	<!--ここまで共通-->
+	<link rel="stylesheet" href="/css/login.css">
 </head>
 
 <body>
 
-	<header></header>
+	<!-- 共通ヘッダーの読み込み -->
+	<header th:replace="header"></header>
 
-	<main>
+	<main class="container">
 		<div>
-			<h2>新規登録</h2>
+			<h1>新規登録</h1>
 		</div>
 
-		<form action="/account/register" method="post" th:object="${guest}">
-			<div>
-				<input type="text" th:field="${guest.name}" class=""
-				 placeholder="名前" required pattern=".{3,15}" title="※名前は3～15文字以内" />
+		<form class="login-items" action="/account/register" method="post" th:object="${guest}">
+			<div class="login-item">
+				<input type="text" th:field="${guest.name}" class="" placeholder="名前" required pattern=".{3,15}"
+					title="※名前は3～15文字以内" />
+			</div>
+			<div class="error-box">
 				<div th:if="${#fields.hasErrors('name')}" th:errors="${guest.name}"></div>
 			</div>
-			<div>
-				<input type="email" th:field="${guest.email}" class=""
-				 placeholder="メールアドレス" required />
+			<div class="login-item">
+				<input type="email" th:field="${guest.email}" class="" placeholder="メールアドレス" required />
+			</div>
+			<div class="error-box">
 				<div th:if="${#fields.hasErrors('email')}" th:errors="${guest.email}"></div>
 			</div>
-			<div>
+			<div class="login-item">
 				<input type="tel" th:field="${guest.tel}" placeholder="電話番号(ハイフンなし)" required pattern="^[0-9]{10,15}$"
-				         title="※10〜15桁の数字を入力してください(ハイフンなし)" maxlength="15" />
+					title="※10〜15桁の数字を入力してください(ハイフンなし)" maxlength="15" />
+			</div>
+			<div class="error-box">
 				<div th:if="${#fields.hasErrors('tel')}" th:errors="${guest.tel}"></div>
 			</div>
-			<div>
-				<input type="text" th:field="${guest.address}" class=""
-				 placeholder="住所" maxlength="120" />
+			<div class="login-item">
+				<input type="text" th:field="${guest.address}" class="" placeholder="住所" maxlength="120" />
+			</div>
+			<div class="error-box">
 				<div th:if="${#fields.hasErrors('address')}" th:errors="${guest.address}"></div>
 			</div>
-			<div>
-				<input type="password" th:field="${guest.password}" class=""
-				 placeholder="パスワード" required pattern="^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{5,}$" title="※英数字を含む5文字以上" />
+			<div class="login-item">
+				<input type="password" th:field="${guest.password}" class="" placeholder="パスワード" required
+					pattern="^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{5,}$" title="※英数字を含む5文字以上" />
+			</div>
+			<div class="error-box">
 				<div th:if="${#fields.hasErrors('password')}" th:errors="${guest.password}"></div>
 			</div>
-			<div>
-				<input type="password" name="password_confirm" class=""
-				 placeholder="パスワード（確認）" required />
+			<div class="login-item">
+				<input type="password" name="password_confirm" class="" placeholder="パスワード（確認）" required />
+			</div>
+			<div class="error-box">
 				<div th:if="${error != null}" th:text="${error}"></div>
 			</div>
-			<button>新規会員登録</button>
+			<button class="login-buttons">新規会員登録</button>
 		</form>
-		<div>
-			<a href="/login">ログインページへ</a>
+
+		<div class="register-button">
+			アカウントを既にお持ちの方は
+			<a href="/login">ログイン</a>
 		</div>
 	</main>
+
+	<!-- 共通ヘッダーの読み込み -->
+	<footer th:replace="footer"></footer>
 
 </body>
 

--- a/src/main/resources/templates/reservation-detail.html
+++ b/src/main/resources/templates/reservation-detail.html
@@ -4,67 +4,71 @@
 <head>
 	<meta charset="UTF-8">
 	<title>予約確認ページ</title>
-	<link rel="stylesheet" type="text/css" href="/css/style.css">
+	<!-- フォントやアイコンなどの読み込み -->
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
+	<!-- Font Awesome -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+	<!-- 共通CSS -->
+	<link rel="stylesheet" href="/css/style.css">
+	<link rel="stylesheet" href="/css/shadow.css">
+	<link rel="stylesheet" href="/css/header-footer.css">
+	<!--ここまで共通-->
+	<link rel="stylesheet" href="/css/history-contents.css">
 
 </head>
 
 <body>
 	<header th:replace="header"></header>
 
-	<main>
+	<main class="reservation-history">
 
 		<h1 th:text="${afterReserveText}"></h1>
 
-		<div class="">
-			<p>部屋名：</p>
-			<div class="" th:text="${reservationHistory.room.roomName}"></div>
+		<div class="history-detail">
 
-			<p>プラン名：</p>
-			<div class="" th:text="${reservationHistory.plan.name}"></div>
-
-			<p>チェックイン〜チェックアウト：</p>
-			<div class="" th:text="${reservationHistory.StayDate}"></div>
-			<div class="" th:text="${checkoutDate}"></div>
-			<p>合計金額：</p>
-			<div class="" th:text="${reservationHistory.totalPrice}"></div>
-			<p>人数</p>
-			<div class="" th:text="${reservationHistory.guestCount} + '人'"></div>
+			<img class="history-detail__img" th:src="@{${reservationHistory.room.imgPath}}">
 
 
-
-			<div class="room-img" id="slide">
-				<img th:src="@{${reservationHistory.room.imgPath}}" id="room-img">
-				<span id="prevBtn" onclick="prev()">&lt;</span>
-				<span id="nextBtn" onclick="next()">&gt;</span>
-				
-
-				<script th:inline="javascript">
-					const imgs = /*[[${imgList}]]*/[]; //画像の配列
-					let num = 0;
-					function showImage() {
-						document.getElementById("room-img").src = imgs[num];
-						const img = document.getElementById("room-img");
-						img.classList.add("fade-out");
-						setTimeout(() => {
-							img.src = imgs[num]; // 新しい画像に切り替え
-							img.classList.remove("fade-out");
-						}, 250); // 画像切り替えはフェードの途中で実行
-					}
-					function next() {
-						num = (num + 1) % imgs.length;  // 配列の最後までいったら先頭に戻る
-						showImage(); //現在の num の値に対応する画像を画面に表示するための関数を呼び出し
-					}
-					function prev() {
-						num = (num - 1 + imgs.length) % imgs.length;  // 最初の画像の前は最後に戻る
-						showImage(); //現在の num の値に対応する画像を画面に表示するための関数を呼び出し
-					}
-					// ページ読み込み時に最初の画像表示
-					showImage();
-				</script>
-
+			<div class="history-detail__contents">
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">ステータス</div>
+					<div class="detail-contents__body">[[${reservationHistory.room.roomName}]]</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">宿泊部屋</div>
+					<div class="detail-contents__body">[[${reservationHistory.room.roomName}]]</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">プラン</div>
+					<div class="detail-contents__body">[[${reservationHistory.plan.name}]]</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">チェックイン日</div>
+					<div class="detail-contents__body">[[${reservationHistory.StayDate}]]</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">チェックアウト日</div>
+					<div class="detail-contents__body">[[${checkoutDate}]]</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">宿泊人数</div>
+					<div class="detail-contents__body">[[${reservationHistory.guestCount}]]人</div>
+				</div>
+				<div class="detail-contents-row">
+					<div class="detail-contents__title">合計金額</div>
+					<div class="detail-contents__body">[[${reservationHistory.totalPrice}]]円</div>
+				</div>
 			</div>
-			
-			<div><a href="/reservationHistory">予約履歴へ</a></div>
+
+			<div class="history-detail-btn">
+				<a href="/reservationHistory">
+					<button type="button">
+						予約履歴一覧へ
+					</button>
+				</a>
+			</div>
 
 		</div>
 	</main>

--- a/src/main/resources/templates/reservation-history.html
+++ b/src/main/resources/templates/reservation-history.html
@@ -7,40 +7,63 @@
 	<!-- フォントやアイコンなどの読み込み -->
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap" rel="stylesheet">
-	<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+	<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
+	<!-- Font Awesome -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+	<!-- 共通CSS -->
 	<link rel="stylesheet" href="/css/style.css">
+	<link rel="stylesheet" href="/css/shadow.css">
+	<link rel="stylesheet" href="/css/header-footer.css">
 	<!--ここまで共通-->
-	<link rel="stylesheet" type="text/css" href="/css/style.css">
+	<link rel="stylesheet" href="/css/history-contents.css">
+
 
 </head>
 
 <body>
 	<header th:replace="header"></header>
-	<main>
-		<h1>予約履歴</h1>
-		<ul>
-			<li th:each="reservHistory:${reservationHistorys}">
 
-				<div class="">
-					<img th:src="@{${reservHistory.room.imgPath}}" alt="部屋">
+	<main class="reservation-history">
+
+		<h1>予約履歴</h1>
+
+		<div class="history-list" th:each="reservHistory:${reservationHistorys}">
+			<div class="list-contents">
+				<div>
+					<img class="history-img" th:src="@{${reservHistory.room.imgPath}}" alt="部屋">
 				</div>
-				<div class="">
-					<div class="" th:text="${reservHistory.room.roomName}"></div>
-					<div class="" th:text="${reservHistory.plan.name}"></div>
-					<div class="" th:text="${reservHistory.StayDate}"></div>
-					<div class="" th:text="${reservHistory.totalPrice}"></div>
+				<div class="history-info">
+					<div class="history-info__contents">
+						<h3>宿泊部屋：<span class="theme-color">[[${reservHistory.room.roomName}]]</span></h3>
+						<div>ステータス：</div>
+						<div>プラン：[[${reservHistory.plan.name}]]</div>
+						<div>宿泊日：[[${reservHistory.StayDate}]]</div>
+					</div>
+
+					<div class="history-info__btn">
+						<a th:href="@{/reservationHistory/{id}(id=${reservHistory.id})}">
+							<button class="history-btn">
+								<i class="fa-solid fa-circle-info"></i>
+								ご予約内容の確認
+							</button>
+						</a>
+						<a th:if="${!reservHistory.isReviewedBy(loginGuestId)}"
+							th:href="@{/reviews/new/{id}(id=${reservHistory.id})}">
+							<button class="review-btn" type="button">
+								<i class="fa-solid fa-comment"></i>
+								レビューを書く
+							</button>
+						</a>
+						<span th:if="${reservHistory.isReviewedBy(loginGuestId)}">
+							<button class="review-disabled" type="button">
+								<i class="fa-solid fa-comment"></i>
+								レビュー投稿済み
+							</button>
+						</span>
+					</div>
 				</div>
-				<a th:href="@{/reservationHistory/{id}(id=${reservHistory.id})}">詳細を見る</a>
-				<a th:if="${!reservHistory.isReviewedBy(loginGuestId)}"
-					th:href="@{/reviews/new/{id}(id=${reservHistory.id})}">
-					レビューを書く
-				</a>
-				<span th:if="${reservHistory.isReviewedBy(loginGuestId)}">
-					レビュー投稿済み
-				</span>
-			</li>
-		</ul>
+			</div>
+		</div>
 	</main>
 	<footer th:replace="footer"></footer>
 


### PR DESCRIPTION
## 新規ユーザー登録
既に作成済みのログイン画面に合わせてレイアウトは調整しています

<img width="1025" height="683" alt="スクリーンショット 2025-07-13 15 07 27" src="https://github.com/user-attachments/assets/f83ac306-9783-438c-ab45-025c03f8743c" />

新規登録画面のヘッダーについてですが、「ログイン画面へ」の案内部分は必要なく、ログインと同じレイアウトで問題ないかと思います
また、「ログイン画面へ」の案内部分があるヘッダーのレイアウトが若干、他のレイアウトと比べて下寄りになっているので、確認お願いします

<img width="1339" height="277" alt="スクリーンショット 2025-07-13 15 08 13" src="https://github.com/user-attachments/assets/db084440-e76f-4217-84ae-13066237ef02" />

## 予約履歴関連
細かな部分は一旦置いて、全体のレイアウトの調整を行いました
また、レイアウトチェックのときや動作テストのときに意見交換できればと思います

<img width="1165" height="608" alt="スクリーンショット 2025-07-13 15 04 17" src="https://github.com/user-attachments/assets/8e2f0b9b-73e0-4700-90d8-ccc2c153a71d" />

<img width="1196" height="624" alt="スクリーンショット 2025-07-13 15 05 03" src="https://github.com/user-attachments/assets/d83530fd-9d13-458b-8f59-8cedc1098ee9" />

<img width="993" height="647" alt="スクリーンショット 2025-07-13 15 05 13" src="https://github.com/user-attachments/assets/30e47834-d5f0-4644-bdc4-6c52300ee748" />